### PR TITLE
Fix typo

### DIFF
--- a/hass-postgresql-backup
+++ b/hass-postgresql-backup
@@ -59,7 +59,7 @@ function determine-compressor() {
       EXTENSION='bz2'
       debug "Found pbzip2"
     fi
-  elss
+  else
     debug "Per environment, using ${COMPRESSOR} to compress"
   fi
   debug "Will compress with ${COMPRESSOR} ${COMPRESSION_ARGS}..."


### PR DESCRIPTION
# Description

This is what I get for having one public repo and another internal one and copying things between.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: [x] -->

- [ ] New feature
- [x] Bugfix
- [ ] Text cleanups/updates
- [ ] Test updates

# License Acceptance

- [x] This repository is Apache version 2.0 licensed, and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. [x] -->
<!--- If you're unsure about any of these, don't hesitate to ask. I'm happy to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests pass.
- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of potentially platform-specific direct paths (`#!/bin/sh` is an allowed exception)
- [x] Scripts added/updated in this PR are all marked executable.
- [x] Scripts added/updated in this PR _do not_ have a language file extension unless they are meant to be sourced and not run standalone. No one should have to know if a script was written in bash, python, ruby or whatever. Not including file extensions makes it easier to rewrite the script in another language later without having to change every reference to the previous version.
- [ ] I have confirmed that any link(s) in my PR work as of the time the PR was created.
